### PR TITLE
Undefined behavior: program abort when there are small/empty matrix in cool file

### DIFF
--- a/tadlib/hitad/chromLev.py
+++ b/tadlib/hitad/chromLev.py
@@ -101,7 +101,13 @@ class Chrom(object):
         self.hmm = None
 
         x, y = hicdata.nonzero()
-        IF = np.array(hicdata[x, y]).ravel()
+        mat_ = hicdata[x, y]
+        if isinstance(mat_, np.matrix):
+            IF = np.array(mat_).ravel()
+        else:
+            # mat_ is a sparse matrix
+            IF = np.array(mat_.todense()).ravel()
+
         IF[np.isnan(IF)] = 0
         self.rawMatrix = self._genSparseMatrix(x, y, IF)
         self._mw = min(self.maxapart//res, self.chromLen)


### PR DESCRIPTION
Hello,

Thanks a lot for supporting Python3 and the cool file, it very useful for me.
But when I use this new version to process my own data, I found there are some problem. The error message like this:

```
tadlib.hitad.genomeLev    DEBUG   @ 12/01/18 13:49:56: Chrom Y:
tadlib.hitad.genomeLev    DEBUG   @ 12/01/18 13:49:56:   resolution: 5000, rep1
tadlib.hitad.genomeLev    DEBUG   @ 12/01/18 13:49:56:   Cache Chrom object into /home/nanguage/.hitad/tmpq1ukaxsj20181201134956 ...
tadlib.hitad.genomeLev    DEBUG   @ 12/01/18 13:49:59: Chrom MT:
tadlib.hitad.genomeLev    DEBUG   @ 12/01/18 13:49:59:   resolution: 5000, rep1
Traceback (most recent call last):
  File "/home/nanguage/S/miniconda3/bin/hitad", line 107, in run
    G = Genome(args.datasets, args.maxsize, cachefolder)
  File "/home/nanguage/S/miniconda3/lib/python3.6/site-packages/tadlib/hitad/genomeLev.py", line 89, in __init__
    work = Chrom(chrom, res, tdata, rep, maxsize)
  File "/home/nanguage/S/miniconda3/lib/python3.6/site-packages/tadlib/hitad/chromLev.py", line 105, in __init__
    IF[np.isnan(IF)] = 0
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```
Then I try to debug it, I found that this error occurs when there are small or empty matrix in the cool file (like the 'chrMT' in above case, it's a very small matrix). I know, I can prevent this by rebuild the cool file exclude the 'chrMT', but I think this is an undefined behavior, program should ignore it instead of interrupted. So I fix this by modify a few lines of code, maybe it is not a good solution, but it works for this situtation.