### PR TITLE
Passing int(snum) rather than relying on numpy.linspace().

### DIFF
--- a/tadlib/calfea/analyze.py
+++ b/tadlib/calfea/analyze.py
@@ -532,7 +532,7 @@ def _fitting(x, y):
     times = np.arange(2, 4)
     scheck = x.size / times
     snum = scheck[scheck > 6][-1] if (scheck > 6).sum() > 0 else x.size
-    xi = np.linspace(x.min(), x.max(), snum)
+    xi = np.linspace(x.min(), x.max(), int(snum))
     yi = ip(xi)
     
     ## B-spline


### PR DESCRIPTION
Version 1.19.1 of numpy.linspace() throws an exception when the third argument is a float.
It seems its internal call to operator.index() ought to handle it, but an exception is
thrown.
